### PR TITLE
Fix/remove dramatiq et al

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,11 +55,12 @@ test:
   requires:
     - python {{ python_min }}
     - pip
+    - pipdeptree
   imports:
     - tom_targets
     - tom_observations
   commands:
-    - pip check
+    - pipdeptree
 
 about:
   home: https://github.com/TOMToolkit/tom_base

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,7 +48,7 @@ requirements:
     - plotly <6
     - python-dateutil <3
     - requests <3
-    - specutils <2
+    - specutils >=1.17,<2
     - importlib-resources >=6.4.5,<6.5.0
 
 test:


### PR DESCRIPTION
This PR updates the recipe’s dependency constraints and test tooling in recipe/meta.yaml, specifically tightening the specutils version range and replacing the pip check command with pipdeptree in tests.

    Enforce specutils ≥1.17,<2 instead of just <2
    Add pipdeptree to test requirements and use it in test commands

